### PR TITLE
Fix Urban Dictionary plugin's CR/CRLF/LF handling

### DIFF
--- a/plugins/urban_dictionary.rb
+++ b/plugins/urban_dictionary.rb
@@ -38,7 +38,7 @@ class UrbanDictionary < YossarianPlugin
 
 			if hash['list'].nonempty?
 				list = hash['list'].first
-				definition = list['definition'][0..255].gsub(/[\r\n]/, '')
+				definition = list['definition'][0..255].gsub(/[\r\n]+/, ' ')
 				link = list['permalink']
 				m.reply "#{phrase} - #{definition}... (#{link})", true
 			else


### PR DESCRIPTION
This way newlines used as whitespace will be preserved.