### PR TITLE
Rubocop Style Fixes

### DIFF
--- a/old_plugins/jerkcity.rb
+++ b/old_plugins/jerkcity.rb
@@ -44,7 +44,7 @@ class Jerkcity < YossarianPlugin
   match /jerkcity$/, method: :jerkcity
 
   def jerkcity(m)
-    if @comic_count > 0
+    if @comic_count.positive?
       rand = Random.rand(1..@comic_count)
       comic_url = "#{URL}/_jerkcity#{rand}.html"
 

--- a/plugins/decisions.rb
+++ b/plugins/decisions.rb
@@ -27,7 +27,7 @@ class Decisions < YossarianPlugin
   def decide(m, query)
     choices = query.split(/ (?:OR|or|\|\|) /).map(&:strip).map(&:downcase).uniq
     if choices.size < 2
-      m.reply %w(Yep. Nope.).sample, true
+      m.reply %w[Yep. Nope.].sample, true
     else
       m.reply choices.sample, true
     end

--- a/yossarian-bot.rb
+++ b/yossarian-bot.rb
@@ -35,6 +35,7 @@ else
   abort("Fatal: Missing one of: config.yml, version.yml, plugins.yml.")
 end
 
+# rubocop:disable Metrics/BlockLength
 config["servers"].each do |server_name, server_info|
   server_threads << Thread.new do
     Cinch::Bot.new do
@@ -99,5 +100,6 @@ config["servers"].each do |server_name, server_info|
     end.start
   end
 end
+# rubocop:enable Metrics/BlockLength
 
 server_threads.each(&:join)


### PR DESCRIPTION
Helps address #53 by finishing the last of some style fixes.

I didn't see a good way to refactor the config block in `yossarian_bot.rb`, so I'm excluding it from the rubocop check.