### PR TITLE
update rubocop syntax

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,10 @@ Style/StringLiterals:
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 Style/FormatString:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -327,26 +327,6 @@ Style/SymbolProc:
   Exclude:
     - 'plugins/channel_admin.rb'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForMultiline, SupportedStylesForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaArrayInLiteral:
-  Exclude:
-    - 'plugins/catch22.rb'
-    - 'plugins/crypto.rb'
-    - 'plugins/magic8ball.rb'
-
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForMultiline, SupportedStylesForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaHashInLiteral:
-  Exclude:
-    - 'plugins/catch22.rb'
-    - 'plugins/crypto.rb'
-    - 'plugins/magic8ball.rb'
-
 # Offense count: 3
 # Cop supports --auto-correct.
 Style/UnneededInterpolation:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -331,7 +331,17 @@ Style/SymbolProc:
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleForMultiline, SupportedStylesForMultiline.
 # SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaArrayInLiteral:
+  Exclude:
+    - 'plugins/catch22.rb'
+    - 'plugins/crypto.rb'
+    - 'plugins/magic8ball.rb'
+
+# Offense count: 4
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyleForMultiline, SupportedStylesForMultiline.
+# SupportedStylesForMultiline: comma, consistent_comma, no_comma
+Style/TrailingCommaHashInLiteral:
   Exclude:
     - 'plugins/catch22.rb'
     - 'plugins/crypto.rb'

--- a/plugins/catch22.rb
+++ b/plugins/catch22.rb
@@ -48,7 +48,7 @@ class Catch22 < YossarianPlugin
     "There was one catch, and that was Catch-22.",
     "He was a militant idealist who crusaded against racial bigotry by growing faint in its presence.",
     "Aarfy was a dedicated fraternity man who loved cheerleading and class reunions and did not have brains enough to be afraid.",
-    "Any fool can make money these days and most of them do. But what about people with talent and brains? Name, for example, one poet who makes money."
+    "Any fool can make money these days and most of them do. But what about people with talent and brains? Name, for example, one poet who makes money.",
   ]
 
   def usage

--- a/plugins/crypto.rb
+++ b/plugins/crypto.rb
@@ -68,9 +68,9 @@ class Crypto < YossarianPlugin
       changes: {
         hourly: hash["percent_change_1h"],
         daily: hash["percent_change_24h"],
-        weekly: hash["percent_change_7d"]
+        weekly: hash["percent_change_7d"],
       },
-      currency: currency
+      currency: currency,
     }
   end
 

--- a/plugins/magic8ball.rb
+++ b/plugins/magic8ball.rb
@@ -34,7 +34,7 @@ class Magic8Ball < YossarianPlugin
     "My reply is no.",
     "My sources say no.",
     "Outlook not so good.",
-    "Very doubtful."
+    "Very doubtful.",
   ]
 
   def usage


### PR DESCRIPTION
```
Error: The `Style/TrailingCommaInLiteral` cop has been removed. Please use `Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingCommaInHashLiteral` instead.
(obsolete configuration found in .rubocop_todo.yml, please update it)
```
ran into this ever since I used rubocop on yossarian-bot stuff, fixed it, then never remembered to make a pr or anything about it. this is that

I made the assumption `TrailingCommaInLiteral `would be correctly replaced by adding both `TrailingCommaInArrayLiteral` and `TrailingCommaInHashLiteral`, but I'm not sure what the original functionality was.