### PR TITLE
add corona plugin

### DIFF
--- a/plugins.yml
+++ b/plugins.yml
@@ -15,6 +15,7 @@ plugins:
     - Clickbait
     - CommandHelp
     - CodeEval
+    - Corona
     - Crypto
     - CSTopics
     - CTCPVersion

--- a/plugins/corona.rb
+++ b/plugins/corona.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "covid19_data_ruby"
 require "json"
 
 require_relative "yossarian_plugin"

--- a/plugins/corona.rb
+++ b/plugins/corona.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "open-uri"
 require "json"
 
 require_relative "yossarian_plugin"

--- a/plugins/corona.rb
+++ b/plugins/corona.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "covid19_data_ruby"
+require "json"
+
+require_relative "yossarian_plugin"
+
+class Corona < YossarianPlugin
+  include Cinch::Plugin
+  use_blacklist
+
+  BASE_URL = "https://corona.lmao.ninja/countries"
+
+  def usage
+    "!corona [country] Get the current info about corona"
+  end
+
+  def match?(cmd)
+    cmd =~ /^(!)?corona/
+  end
+
+  match /corona (.+)/, method: :corona, strip_colors: true
+
+  def corona(m, country)
+    api_endpoint = "#{BASE_URL}/#{country}"
+    hash = JSON.parse(URI.open(api_endpoint).read)
+    m.reply "COVID-19 in #{hash["country"]} | Total: #{hash["cases"]} cases(#{hash["critical"]} critical), #{hash["deaths"]} deaths, #{hash["recovered"]} recovered. Today: #{hash["todayCases"]} cases, #{hash["todayDeaths"]} deaths.", true
+
+  rescue OpenURI::HTTPError => e
+    m.reply "Nothing found for country '#{country}'.", true
+  rescue Exception => e
+    m.reply e.to_s, true
+  end
+
+end


### PR DESCRIPTION
so after looking around all the covid-19 information apis seem lackluster at the moment [the jhu api](https://github.com/ExpDev07/coronavirus-tracker-api) is decent but slightly out of date and lacking in some info. and the [novelcovid api](https://github.com/NovelCOVID/API) is more up to date but only (without pain) does country searching.

for now I've quickly thrown all, imo, useful info in a simple search command for the novilcovid country api:
![image](https://user-images.githubusercontent.com/15038414/77860326-25523d80-71fe-11ea-97ce-03dacbdfe7d5.png)
I'm sure as always there's many terrible things and format choices I've made, please let me know.

#### reference:
- [novilcovid api overview](https://documenter.getpostman.com/view/8854915/SzS7R6uu?version=latest#e06bbf79-c150-4851-8a42-6a7faafa0f7e) (the one I use currently)
- [jhu api overview](https://coronavirus-tracker-api.herokuapp.com/) (atm outdated and incomplete, but neat if slightly improved)