### PR TITLE
allow for , in decisions

### DIFF
--- a/plugins/decisions.rb
+++ b/plugins/decisions.rb
@@ -25,7 +25,7 @@ class Decisions < YossarianPlugin
   match /decide (.+)/, method: :decide, strip_colors: true
 
   def decide(m, query)
-    choices = query.split(/ (?:OR|or|\|\||,) |, | ,|,/).map(&:strip).map(&:downcase).uniq
+    choices = query.split(/ (?:OR|or|\|\|) |,/).map(&:strip).map(&:downcase).uniq
     if choices.size < 2
       m.reply %w[Yep. Nope.].sample, true
     else

--- a/plugins/decisions.rb
+++ b/plugins/decisions.rb
@@ -25,7 +25,7 @@ class Decisions < YossarianPlugin
   match /decide (.+)/, method: :decide, strip_colors: true
 
   def decide(m, query)
-    choices = query.split(/ (?:OR|or|\|\|) /).map(&:strip).map(&:downcase).uniq
+    choices = query.split(/ (?:OR|or|\|\||,) |, | ,|,/).map(&:strip).map(&:downcase).uniq
     if choices.size < 2
       m.reply %w[Yep. Nope.].sample, true
     else


### PR DESCRIPTION
old situation:
![image](https://user-images.githubusercontent.com/15038414/95335077-75414980-089e-11eb-9ec9-5856cfc385ba.png)
now:
![image](https://user-images.githubusercontent.com/15038414/95335131-85592900-089e-11eb-8575-d9dd598002db.png)

I know not all of these cases make gramatical sense but this is what I've seen people use (without much success) this also stops me from getting answers like "soup, sandwich" when asking for midnight snacks