### PR TITLE
use addressable for URI.encode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "addressable"
 gem "daemons"
 gem "duck-duck-go"
 gem "flippy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable
   daemons
   duck-duck-go
   flippy

--- a/old_plugins/google_search.rb
+++ b/old_plugins/google_search.rb
@@ -8,6 +8,7 @@
 #  This code is licensed by William Woodruff under the MIT License.
 #  http://opensource.org/licenses/MIT
 
+require "addressable/uri"
 require "json"
 require "open-uri"
 
@@ -30,7 +31,7 @@ class GoogleSearch < YossarianPlugin
   match /g(?:oogle)? (.+)/, method: :google_search, strip_colors: true
 
   def google_search(m, search)
-    query = URI.encode(search)
+    query = Addressable::URI.encode(search)
     url = URL % { query: query }
 
     begin

--- a/old_plugins/google_translate.rb
+++ b/old_plugins/google_translate.rb
@@ -8,6 +8,7 @@
 #  This code is licensed by William Woodruff under the MIT License.
 #  http://opensource.org/licenses/MIT
 
+require "addressable/uri"
 require "json"
 require "open-uri"
 
@@ -30,7 +31,7 @@ class GoogleTranslate < YossarianPlugin
   match /tr(?:anslate)? (.+)/, method: :google_translate_auto, strip_colors: true
 
   def google_translate_auto(m, msg)
-    query = URI.encode(msg)
+    query = Addressable::URI.encode(msg)
     url = URL % { query: query }
 
     begin

--- a/old_plugins/searx.rb
+++ b/old_plugins/searx.rb
@@ -8,6 +8,7 @@
 #  This code is licensed by William Woodruff under the MIT License.
 #  http://opensource.org/licenses/MIT
 
+require "addressable/uri"
 require "json"
 require "open-uri"
 
@@ -30,7 +31,7 @@ class Searx < YossarianPlugin
   match /s (.+)/, method: :searx_search, strip_colors: true
 
   def searx_search(m, search)
-    query = URI.encode(search)
+    query = Addressable::URI.encode(search)
     url = URL % { query: query }
 
     begin

--- a/plugins/beer_search.rb
+++ b/plugins/beer_search.rb
@@ -8,6 +8,7 @@
 #  This code is licensed by William Woodruff under the MIT License.
 #  http://opensource.org/licenses/MIT
 
+require "addressable/uri"
 require "json"
 require "open-uri"
 
@@ -32,7 +33,7 @@ class BeerSearch < YossarianPlugin
 
   def beer_search(m, search)
     if KEY
-      query = URI.encode(search)
+      query = Addressable::URI.encode(search)
       url = URL % { key: KEY, query: query }
 
       begin

--- a/plugins/giphy.rb
+++ b/plugins/giphy.rb
@@ -8,6 +8,7 @@
 #  This code is licensed by William Woodruff under the MIT License.
 #  http://opensource.org/licenses/MIT
 
+require "addressable/uri"
 require "json"
 require "open-uri"
 
@@ -32,7 +33,7 @@ class Giphy < YossarianPlugin
 
   def giphy(m, search)
     if KEY
-      query = URI.encode(search)
+      query = Addressable::URI.encode(search)
       url = URL % { query: query, key: KEY }
 
       begin

--- a/plugins/github_info.rb
+++ b/plugins/github_info.rb
@@ -8,6 +8,7 @@
 #  This code is licensed by William Woodruff under the MIT License.
 #  http://opensource.org/licenses/MIT
 
+require "addressable/uri"
 require "json"
 require "open-uri"
 
@@ -41,7 +42,7 @@ class GitHubInfo < YossarianPlugin
   end
 
   def github_user_info(m, user)
-    url = USER_URL % { user: URI.encode(user) }
+    url = USER_URL % { user: Addressable::URI.encode(user) }
 
     begin
       hash = JSON.parse(URI.open(url).read)
@@ -63,7 +64,7 @@ class GitHubInfo < YossarianPlugin
   end
 
   def github_repo_info(m, user, repo)
-    url = REPO_URL % { user: URI.encode(user), repo: URI.encode(repo) }
+    url = REPO_URL % { user: Addressable::URI.encode(user), repo: Addressable::URI.encode(repo) }
 
     begin
       hash = JSON.parse(URI.open(url).read)

--- a/plugins/ip_info.rb
+++ b/plugins/ip_info.rb
@@ -9,6 +9,7 @@
 #  This code is licensed by William Woodruff under the MIT License.
 #  http://opensource.org/licenses/MIT
 
+require "addressable/uri"
 require "resolv"
 require "json"
 require "open-uri"
@@ -33,7 +34,7 @@ class IPInfo < YossarianPlugin
 
   def ip_info(m, ip)
     if ip =~ Resolv::IPv4::Regex || ip =~ Resolv::IPv6::Regex
-      url = URL % { ip: URI.encode(ip) }
+      url = URL % { ip: Addressable::URI.encode(ip) }
 
       begin
         hash = JSON.parse(URI.open(url).read)

--- a/plugins/isitup.rb
+++ b/plugins/isitup.rb
@@ -8,6 +8,7 @@
 #  This code is licensed by William Woodruff under the MIT License.
 #  http://opensource.org/licenses/MIT
 
+require "addressable/uri"
 require "json"
 require "open-uri"
 
@@ -30,7 +31,7 @@ class IsItUp < YossarianPlugin
   match /(?:isit)?up (.+)/, method: :isitup, strip_colors: true
 
   def isitup(m, site)
-    domain = URI.encode(site.gsub(/^http(?:s)?:\/\//, ""))
+    domain = Addressable::URI.encode(site.gsub(/^http(?:s)?:\/\//, ""))
     url = URL % { domain: domain }
 
     begin

--- a/plugins/merriam_webster.rb
+++ b/plugins/merriam_webster.rb
@@ -8,6 +8,7 @@
 #  This code is licensed by William Woodruff under the MIT License.
 #  http://opensource.org/licenses/MIT
 
+require "addressable/uri"
 require "nokogiri"
 require "open-uri"
 
@@ -32,7 +33,7 @@ class MerriamWebster < YossarianPlugin
 
   def define_word(m, word)
     if KEY
-      query = URI.encode(word)
+      query = Addressable::URI.encode(word)
       url = URL % { query: query, key: KEY }
 
       begin

--- a/plugins/omdb.rb
+++ b/plugins/omdb.rb
@@ -9,6 +9,7 @@
 #  This code is licensed by William Woodruff under the MIT License.
 #  http://opensource.org/licenses/MIT
 
+require "addressable/uri"
 require "json"
 require "open-uri"
 
@@ -31,7 +32,7 @@ class OMDB < YossarianPlugin
   match /omdb (.+)/, method: :omdb_search, strip_colors: true
 
   def omdb_search(m, title)
-    query = URI.encode(title)
+    query = Addressable::URI.encode(title)
     url = URL % { query: query, key: ENV["OMDB_API_KEY"] }
 
     begin

--- a/plugins/stock_quotes.rb
+++ b/plugins/stock_quotes.rb
@@ -8,6 +8,7 @@
 #  This code is licensed by William Woodruff under the MIT License.
 #  http://opensource.org/licenses/MIT
 
+require "addressable/uri"
 require "open-uri"
 require "json"
 
@@ -30,7 +31,7 @@ class StockQuotes < YossarianPlugin
   match /stock (\w+)$/, method: :stock_quote, strip_colors: true
 
   def stock_quote(m, symbol)
-    symbol = URI.encode(symbol)
+    symbol = Addressable::URI.encode(symbol)
     url = URL % { ticker: symbol, api_key: ENV["ALPHA_VANTAGE_API_KEY"] }
 
     begin

--- a/plugins/tiny_url.rb
+++ b/plugins/tiny_url.rb
@@ -8,6 +8,7 @@
 #  This code is licensed by William Woodruff under the MIT License.
 #  http://opensource.org/licenses/MIT
 
+require "addressable/uri"
 require "open-uri"
 
 require_relative "yossarian_plugin"
@@ -29,7 +30,7 @@ class TinyURL < YossarianPlugin
   match /t(?:iny)?url (#{URI.regexp(['http', 'https'])})/, method: :tinyurl, strip_colors: true
 
   def tinyurl(m, link)
-    url = URL % { link: URI.encode(link) }
+    url = URL % { link: Addressable::URI.encode(link) }
 
     begin
       short_link = URI.open(url).read

--- a/plugins/urban_dictionary.rb
+++ b/plugins/urban_dictionary.rb
@@ -8,6 +8,7 @@
 #  This code is licensed by William Woodruff under the MIT License.
 #  http://opensource.org/licenses/MIT
 
+require "addressable/uri"
 require "json"
 require "open-uri"
 
@@ -31,7 +32,7 @@ class UrbanDictionary < YossarianPlugin
   match /urban (.+)/, method: :urban_dict, strip_colors: true
 
   def urban_dict(m, phrase)
-    query = URI.encode(phrase)
+    query = Addressable::URI.encode(phrase)
     url = URL % { query: query }
 
     begin

--- a/plugins/weather.rb
+++ b/plugins/weather.rb
@@ -8,6 +8,7 @@
 #  This code is licensed by William Woodruff under the MIT License.
 #  http://opensource.org/licenses/MIT
 
+require "addressable/uri"
 require "net/http"
 require "json"
 require_relative "yossarian_plugin"
@@ -36,7 +37,7 @@ class Weather < YossarianPlugin
           :query => location
         }
         uri = URI("http://api.weatherstack.com/current")
-        uri.query = URI.encode_www_form(params)
+        uri.query = Addressable::URI.encode_www_form(params)
         json = Net::HTTP.get(uri)
         hsh = JSON.parse(json)
       if hsh["location"]

--- a/plugins/web_search.rb
+++ b/plugins/web_search.rb
@@ -9,6 +9,7 @@
 #  This code is licensed by William Woodruff under the MIT License.
 #  http://opensource.org/licenses/MIT
 
+require "addressable/uri"
 require "json"
 require "open-uri"
 require "sanitize"
@@ -39,7 +40,7 @@ class WebSearch < YossarianPlugin
       return
     end
 
-    query = URI.encode(search)
+    query = Addressable::URI.encode(search)
     url = URL % { key: KEY, cx: ENGINE_ID, query: query }
 
     begin

--- a/plugins/wikipedia.rb
+++ b/plugins/wikipedia.rb
@@ -8,6 +8,7 @@
 #  This code is licensed by slackErEhth77 under the MIT License.
 #  http://opensource.org/licenses/MIT
 
+require "addressable/uri"
 require "json"
 require "open-uri"
 
@@ -30,7 +31,7 @@ class Wikipedia < YossarianPlugin
   match /wiki (.+)/, method: :search_wiki, strip_colors: true
 
   def search_wiki(m, search)
-    query = URI.encode(search)
+    query = Addressable::URI.encode(search)
     url = URL % { query: query }
 
     begin

--- a/plugins/youtube_search.rb
+++ b/plugins/youtube_search.rb
@@ -8,6 +8,7 @@
 #  This code is licensed by William Woodruff under the MIT License.
 #  http://opensource.org/licenses/MIT
 
+require "addressable/uri"
 require "json"
 require "open-uri"
 
@@ -31,7 +32,7 @@ class YouTubeSearch < YossarianPlugin
   match /youtube (.+)/, method: :youtube_search, strip_colors: true
 
   def youtube_search(m, search)
-    query = URI.encode(search)
+    query = Addressable::URI.encode(search)
     url = URL % { query: query, key: ENV["YOUTUBE_API_KEY"] }
 
     begin


### PR DESCRIPTION
disclaimer: couldnt get yosbot to run on my system at all and I didnt want to keep rubying around. In theory I think this runs, maybe
possibly fixes #178 

largely taken on advice from: https://stackoverflow.com/questions/68635238/undefined-method-encode-for-urimodule-with-gem-rspotify